### PR TITLE
Supporting rolling policies for file appender

### DIFF
--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/appender/FileAppenderFactory.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/appender/FileAppenderFactory.java
@@ -2,6 +2,8 @@ package com.nhl.bootique.logback.appender;
 
 import java.util.Objects;
 
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import ch.qos.logback.classic.LoggerContext;
@@ -11,9 +13,7 @@ import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.rolling.RollingFileAppender;
-import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
-import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
-import ch.qos.logback.core.util.FileSize;
+import com.nhl.bootique.logback.policy.RollingPolicyFactory;
 
 /**
  * A configuration object that sets up a file appender in Logback, potentially
@@ -25,77 +25,31 @@ import ch.qos.logback.core.util.FileSize;
 public class FileAppenderFactory extends AppenderFactory {
 
 	private String file;
-	private boolean rotate;
-	private String maxFileSize;
-	private int maxFiles;
-	private String maxTotalFileSize;
+	private RollingPolicyFactory rollingPolicy;
 
 	/**
-	 * Sets a filename or a filename pattern for the log file. If "rotate" is
-	 * true, the filename can be a pattern per <a href=
-	 * "http://logback.qos.ch/manual/appenders.html#RollingFileAppender">Logback
-	 * documentation</a> that determines time-based rotation interval.
-	 * Additional settings on this factory allow to also cap individual and
-	 * total files sizes and how many total log files can be kept.
+	 * Sets a filename for the current log file.
 	 * 
-	 * @param file
-	 *            a filename or a filename pattern for the log file.
+	 * @param file a filename for the current log file.
 	 */
 	public void setFile(String file) {
 		this.file = file;
 	}
 
 	/**
-	 * Enables or disables file rotation. Default is "false".
-	 * 
-	 * @since 0.9
-	 * @param rotate
-	 *            if true, log file rotation is enabled.
+	 * Rolling policy factory what defines rolling policy for rotation.
+	 * If rolling policy factory is not defined the rotation is not used
+	 *
+	 * @see com.nhl.bootique.logback.policy.RollingPolicyFactory
+	 * @see com.nhl.bootique.logback.policy.FixedWindowPolicyFactory
+	 * @see com.nhl.bootique.logback.policy.TimeBasedPolicyFactory
+	 * @see ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy
+	 *
+	 * @since 0.10
+	 * @param rollingPolicy a rolling policy factory
 	 */
-	public void setRotate(boolean rotate) {
-		this.rotate = rotate;
-	}
-
-	/**
-	 * Sets a maximum size of a single log file. Exceeding this size causes
-	 * rotation. This option is ignored if "rotate" is false.
-	 * 
-	 * @since 0.9
-	 * @param maxFileSize
-	 *            Max size of a single log file expressed in bytes, kilobytes,
-	 *            megabytes or gigabytes by suffixing a numeric value with KB,
-	 *            MB and respectively GB. For example: 5000000, 5000KB, 5MB and
-	 *            2GB.
-	 */
-	public void setMaxFileSize(String maxFileSize) {
-		this.maxFileSize = maxFileSize;
-	}
-
-	/**
-	 * Sets a maximum number of log files to keep. Older files exceeding this
-	 * number will be deleted.
-	 * 
-	 * @since 0.9
-	 * @param maxFiles
-	 *            maximum number of log files to keep.
-	 */
-	public void setMaxFiles(int maxFiles) {
-		this.maxFiles = maxFiles;
-	}
-
-	/**
-	 * Sets a maximum size of all log files combined. Equivalent to Logback
-	 * 'totalSizeCap' property. Requires "maxFiles" to be set.
-	 * 
-	 * @since 0.9
-	 * @param maxTotalFileSize
-	 *            maximum size of all log files combined expressed in bytes,
-	 *            kilobytes, megabytes or gigabytes by suffixing a numeric value
-	 *            with KB, MB and respectively GB. For example: 5000000, 5000KB,
-	 *            5MB and 2GB.
-	 */
-	public void setMaxTotalFileSize(String maxTotalFileSize) {
-		this.maxTotalFileSize = maxTotalFileSize;
+	public void setRollingPolicy(RollingPolicyFactory rollingPolicy) {
+		this.rollingPolicy = rollingPolicy;
 	}
 
 	@Override
@@ -104,9 +58,12 @@ public class FileAppenderFactory extends AppenderFactory {
 		LayoutWrappingEncoder<ILoggingEvent> encoder = new LayoutWrappingEncoder<>();
 		encoder.setLayout(createLayout(context));
 
-		FileAppender<ILoggingEvent> appender = rotate ? createRollingFileAppender(encoder, context)
-				: createSingleFileAppender(encoder, context);
-
+		FileAppender<ILoggingEvent> appender;
+		if (rollingPolicy == null) {
+			appender = createSingleFileAppender(encoder, context);
+		} else {
+			appender = createRollingFileAppender(encoder, context, rollingPolicy);
+		}
 		return asAsync(appender);
 	}
 
@@ -123,62 +80,27 @@ public class FileAppenderFactory extends AppenderFactory {
 	}
 
 	protected FileAppender<ILoggingEvent> createRollingFileAppender(Encoder<ILoggingEvent> encoder,
-			LoggerContext context) {
-
-		TimeBasedRollingPolicy<ILoggingEvent> policy = maxFileSize != null ? createSizeAndTimeRollingPolicy(context)
-				: createTimeRollingPolicy(context);
-
-		if (shouldDeleteOlderFiles()) {
-			setupToDeleteOlderFiles(policy);
-		}
+																	LoggerContext context,
+																	RollingPolicyFactory rollingPolicy) {
 
 		RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
-		appender.setRollingPolicy(policy);
-		policy.setParent(appender);
-
+		appender.setFile(file);
 		appender.setContext(context);
 		appender.setEncoder(encoder);
-
+		// Setup rolling policy
+		RollingPolicy policy = rollingPolicy.createRollingPolicy(context);
+		appender.setRollingPolicy(policy);
+		policy.setParent(appender);
+		// Setup triggering policy
+		TriggeringPolicy<ILoggingEvent> triggeringPolicy = rollingPolicy.createTriggeringPolicy(context);
+		if (triggeringPolicy != null) {
+			appender.setTriggeringPolicy(triggeringPolicy);
+			triggeringPolicy.start();
+		}
 		policy.start();
 		appender.start();
 
 		return appender;
 	}
 
-	protected boolean shouldDeleteOlderFiles() {
-		return maxFiles > 0;
-	}
-
-	protected void setupToDeleteOlderFiles(TimeBasedRollingPolicy<?> policy) {
-
-		policy.setMaxHistory(maxFiles);
-		policy.setCleanHistoryOnStart(true);
-
-		if (maxTotalFileSize != null) {
-			policy.setTotalSizeCap(FileSize.valueOf(maxTotalFileSize));
-		}
-	}
-
-	protected SizeAndTimeBasedRollingPolicy<ILoggingEvent> createSizeAndTimeRollingPolicy(LoggerContext context) {
-
-		// TODO: validate filename pattern... if %i is absent, the logger would
-		// quietly stop working
-
-		SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
-		policy.setMaxFileSize(maxFileSize);
-		policy.setFileNamePattern(file);
-		policy.setContext(context);
-		return policy;
-	}
-
-	protected TimeBasedRollingPolicy<ILoggingEvent> createTimeRollingPolicy(LoggerContext context) {
-
-		// TODO: validate filename pattern... if %d{} is absent, the logger
-		// would quietly stop working
-
-		TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
-		policy.setFileNamePattern(file);
-		policy.setContext(context);
-		return policy;
-	}
 }

--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/FileNamePatternValidator.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/FileNamePatternValidator.java
@@ -1,0 +1,95 @@
+package com.nhl.bootique.logback.policy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.helper.DateTokenConverter;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import ch.qos.logback.core.rolling.helper.IntegerTokenConverter;
+import ch.qos.logback.core.rolling.helper.RollingCalendar;
+
+import java.util.Locale;
+
+public class FileNamePatternValidator {
+
+    private static final String SEE_LOGBACK_APPENDER = "See http://logback.qos.ch/manual/appenders.html";
+    private static final String SEE_TIME_BASED_ROLLING_POLICY = SEE_LOGBACK_APPENDER + "#TimeBasedRollingPolicy";
+    private static final String SEE_SIZE_AND_TIME_BASED_ROLLING_POLICY = SEE_LOGBACK_APPENDER + "#SizeAndTimeBasedRollingPolicy";
+    private static final String SEE_FIXED_WINDOW_ROLLING_POLICY = SEE_LOGBACK_APPENDER + "#FixedWindowRollingPolicy";
+
+    private static final String FILE_NAME_PATTERN_MANDATORY = "The property \"fileNamePattern\" is mandatory";
+    private static final String MISSING_INTEGER_TOKEN = "Missing integer token, that is %%i, in property \"fileNamePattern\" [%s]";
+    private static final String UNEXPECTED_INTEGER_TOKEN = "Unexpected integer token, that is %%i, in property \"fileNamePattern\" [%s]";
+    private static final String MISSING_DATE_TOKEN = "Missing date token, that is %%d, in property \"fileNamePattern\" [%s]";
+    private static final String UNEXPECTED_DATE_TOKEN = "Unexpected date token, that is %%d, in property \"fileNamePattern\" [%s]";
+    private static final String INCORRECT_DATE_FORMAT = "Incorrect date format in the date token in property \"fileNamePattern\" [%s]";
+
+    public static void validate(String fileNamePattern, LoggerContext context, Class<? extends RollingPolicy> policyType) {
+        if (fileNamePattern == null || fileNamePattern.length() == 0) {
+            throw new IllegalStateException(FILE_NAME_PATTERN_MANDATORY);
+        }
+        if (TimeBasedRollingPolicy.class.equals(policyType)) {
+            validateTimeBasedRollingPolicyPattern(fileNamePattern, context);
+        } else if (SizeAndTimeBasedRollingPolicy.class.equals(policyType)) {
+            validateSizeAndTimeBasedRollingPolicyPattern(fileNamePattern, context);
+        } else if (FixedWindowRollingPolicy.class.equals(policyType)) {
+            validateFixedWindowRollingPolicyPattern(fileNamePattern, context);
+        }
+    }
+
+    private static void validateTimeBasedRollingPolicyPattern(String fileNamePattern, LoggerContext context) {
+        checkDateToken(fileNamePattern, context, true, SEE_TIME_BASED_ROLLING_POLICY);
+        checkIntegerToken(fileNamePattern, context, false, SEE_TIME_BASED_ROLLING_POLICY);
+    }
+
+    private static void validateSizeAndTimeBasedRollingPolicyPattern(String fileNamePattern, LoggerContext context) {
+        checkDateToken(fileNamePattern, context, true, SEE_SIZE_AND_TIME_BASED_ROLLING_POLICY);
+        checkIntegerToken(fileNamePattern, context, true, SEE_SIZE_AND_TIME_BASED_ROLLING_POLICY);
+    }
+
+    private static void validateFixedWindowRollingPolicyPattern(String fileNamePattern, LoggerContext context) {
+        checkDateToken(fileNamePattern, context, false, SEE_FIXED_WINDOW_ROLLING_POLICY);
+        checkIntegerToken(fileNamePattern, context, true, SEE_FIXED_WINDOW_ROLLING_POLICY);
+    }
+
+    private static void checkDateToken(String fileNamePattern, LoggerContext context, boolean checkOnExisting, String docHref) {
+        FileNamePattern pattern = new FileNamePattern(fileNamePattern, context);
+        DateTokenConverter<Object> token = pattern.getPrimaryDateTokenConverter();
+        checkToken(token, checkOnExisting, fileNamePattern, docHref, MISSING_DATE_TOKEN, UNEXPECTED_DATE_TOKEN);
+        if (checkOnExisting) {
+            checkDateFormat(token, fileNamePattern, docHref);
+        }
+    }
+
+    private static void checkIntegerToken(String fileNamePattern, LoggerContext context, boolean checkOnExisting, String docHref) {
+        FileNamePattern pattern = new FileNamePattern(fileNamePattern, context);
+        IntegerTokenConverter token = pattern.getIntegerTokenConverter();
+        checkToken(token, checkOnExisting, fileNamePattern, docHref, MISSING_INTEGER_TOKEN, UNEXPECTED_INTEGER_TOKEN);
+    }
+
+    private static void checkToken(Object token, boolean checkOnExisting, String... errorFormatParams) {
+        Integer errorCodeIndex = null;
+        if (checkOnExisting && token == null) {
+            errorCodeIndex = 2;
+        } else if (!checkOnExisting && token != null) {
+            errorCodeIndex = 3;
+        }
+        if (errorCodeIndex != null) {
+            throw new IllegalStateException(String.format("%s %s", String.format(errorFormatParams[errorCodeIndex], errorFormatParams[0]), errorFormatParams[1]));
+        }
+    }
+
+    private static void checkDateFormat(DateTokenConverter<Object> token, String pattern, String docRef) {
+        RollingCalendar rollingCalendar;
+        if (token.getTimeZone() != null) {
+            rollingCalendar = new RollingCalendar(token.getDatePattern(), token.getTimeZone(), Locale.getDefault());
+        } else {
+            rollingCalendar = new RollingCalendar(token.getDatePattern());
+        }
+        if (!rollingCalendar.isCollisionFree()) {
+            throw new IllegalStateException(String.format("%s %s", String.format(INCORRECT_DATE_FORMAT, pattern), docRef));
+        }
+    }
+}

--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/FixedWindowPolicyFactory.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/FixedWindowPolicyFactory.java
@@ -1,0 +1,65 @@
+package com.nhl.bootique.logback.policy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A factory what defines rules for creation fixed-window rolling policy.
+ *
+ * Also, it is necessary to setup size-based triggering policy to appender
+ * @see <a href="http://logback.qos.ch/manual/appenders.html#FixedWindowRollingPolicy">Logback documentation</a>
+ *
+ * @since 0.10
+ */
+@JsonTypeName("fixed")
+public class FixedWindowPolicyFactory extends RollingPolicyFactory {
+
+    private String fileSize;
+
+    /**
+     * Sets a maximum size of a single log file. Exceeding this size causes
+     * rotation.
+     *
+     * @param fileSize
+     *            maximum size of a single log file expressed in bytes, kilobytes,
+     *            megabytes or gigabytes by suffixing a numeric value with KB,
+     *            MB and respectively GB. For example: 5000000, 5000KB, 5MB and
+     *            2GB.
+     */
+    public void setFileSize(String fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    @Override
+    protected FixedWindowRollingPolicy instantiatePolicy(LoggerContext context) {
+		FixedWindowRollingPolicy policy = new FixedWindowRollingPolicy();
+		policy.setFileNamePattern(getFileNamePattern());
+		if (getHistorySize() > 0) {
+			policy.setMinIndex(1);
+			policy.setMaxIndex(getHistorySize());
+		}
+		policy.setContext(context);
+		return policy;
+    }
+
+    @Override
+    public TriggeringPolicy<ILoggingEvent> createTriggeringPolicy(LoggerContext context) {
+        SizeBasedTriggeringPolicy<ILoggingEvent> policy = new SizeBasedTriggeringPolicy<ILoggingEvent>();
+        if (fileSize != null && fileSize.length() > 0) {
+            policy.setMaxFileSize(fileSize);
+        }
+        policy.setContext(context);
+        return policy;
+    }
+
+    @Override
+    protected Class<? extends RollingPolicy> getRollingPolicyType() {
+        return FixedWindowRollingPolicy.class;
+    }
+}

--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/RollingPolicyFactory.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/RollingPolicyFactory.java
@@ -1,0 +1,90 @@
+package com.nhl.bootique.logback.policy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * A base abstract factory for defining of the rolling policy for rotation.
+ * This factory defines file name pattern and history size what are used in all rolling policies
+ *
+ * @see <a href="http://logback.qos.ch/manual/appenders.html#RollingFileAppender">Logback documentation</a>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public abstract class RollingPolicyFactory {
+
+    private String fileNamePattern;
+    private int historySize;
+
+    /**
+     * Sets a filename pattern for the archived log files. The filename can be
+     * a pattern per <a href="http://logback.qos.ch/manual/appenders.html#RollingFileAppender">Logback
+     * documentation</a> that determines time-based or fixed-window rotation interval.
+     *
+     * @param fileNamePattern a filename pattern for the archived log files.
+     */
+    public void setFileNamePattern(String fileNamePattern) {
+        this.fileNamePattern = fileNamePattern;
+    }
+
+    /**
+     * Sets a size of rolling history.
+     * This property controls the maximum number of archive files to keep, asynchronously deleting older files.
+     *
+     * In case of {@link com.nhl.bootique.logback.policy.TimeBasedPolicyFactory} and
+     * {@link com.nhl.bootique.logback.policy.SizeAndTimeBasedPolicyFactory}, for example,
+     * if you specify monthly rollover (fileNamePattern is "logfile-%d{yyyy-MM}.log"), and set historySize to 6,
+     * then 6 months worth of archives files will be kept with files older than 6 months deleted.
+     * Note as old archived log files are removed, any folders which were created for the purpose of log file
+     * archiving will be removed as appropriate.
+     *
+     * In case of {@link com.nhl.bootique.logback.policy.FixedWindowPolicyFactory}, for example,
+     * if you set historySize to 6 then 6 archived files will be kept
+     *
+     * @param historySize a size of rolling history
+     */
+    public void setHistorySize(int historySize) {
+        this.historySize = historySize;
+    }
+
+    protected String getFileNamePattern() {
+        return fileNamePattern;
+    }
+
+    protected int getHistorySize() {
+        return historySize;
+    }
+
+    /**
+     * Creates rolling policy for rotation.
+     * This method validates rolling policy properties before creation policy.
+     *
+     * @param context a logger context
+     * @return a rolling policy for rotation
+     * @throws IllegalStateException if rolling policy properties are incorrect
+     */
+    public RollingPolicy createRollingPolicy(LoggerContext context) {
+        FileNamePatternValidator.validate(fileNamePattern, context, getRollingPolicyType());
+        return instantiatePolicy(context);
+    }
+
+    /**
+     * Creates triggering policy for rotation, if it is necessary.
+     *
+     * @param context a logger context
+     * @return triggering policy for rotation or null
+     */
+    public abstract TriggeringPolicy<ILoggingEvent> createTriggeringPolicy(LoggerContext context);
+
+    /**
+     * Instantiates rolling policy for rotation.
+     *
+     * @param context a logger context
+     * @returna rolling policy for rotation
+     */
+    protected abstract RollingPolicy instantiatePolicy(LoggerContext context);
+
+    protected abstract Class<? extends RollingPolicy> getRollingPolicyType();
+}

--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/SizeAndTimeBasedPolicyFactory.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/SizeAndTimeBasedPolicyFactory.java
@@ -1,0 +1,52 @@
+package com.nhl.bootique.logback.policy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A factory what defines rules for creation size-and-time-based rolling policy.
+ *
+ * It is not needed to add any triggering policy to appender
+ * @see <a href="http://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy">Logback documentation</a>
+ *
+ * @since 0.10
+ */
+@JsonTypeName("size")
+public class SizeAndTimeBasedPolicyFactory extends TimeBasedPolicyFactory {
+
+    private String fileSize;
+
+    /**
+     * Sets a maximum size of a single log file. Exceeding this size causes
+     * rotation.
+     *
+     * @param fileSize
+     *            maximum size of a single log file expressed in bytes, kilobytes,
+     *            megabytes or gigabytes by suffixing a numeric value with KB,
+     *            MB and respectively GB. For example: 5000000, 5000KB, 5MB and
+     *            2GB.
+     */
+    public void setFileSize(String fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    @Override
+    public SizeAndTimeBasedRollingPolicy instantiatePolicy(LoggerContext context) {
+		SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
+        setupBasePolicySettings(policy);
+        if (fileSize != null && fileSize.length() > 0) {
+            policy.setMaxFileSize(fileSize);
+        }
+        policy.setContext(context);
+        return policy;
+    }
+
+    @Override
+    protected Class<? extends RollingPolicy> getRollingPolicyType() {
+        return SizeAndTimeBasedRollingPolicy.class;
+    }
+}

--- a/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/TimeBasedPolicyFactory.java
+++ b/bootique-logback/src/main/java/com/nhl/bootique/logback/policy/TimeBasedPolicyFactory.java
@@ -1,0 +1,69 @@
+package com.nhl.bootique.logback.policy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
+import ch.qos.logback.core.rolling.helper.DateTokenConverter;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import ch.qos.logback.core.util.FileSize;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A factory what defines rules for creation time-based rolling policy.
+ *
+ * It is not needed to add any triggering policy to appender
+ * @see <a href="http://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy">Logback documentation</a>
+ *
+ * @since 0.10
+ */
+@JsonTypeName("time")
+public class TimeBasedPolicyFactory extends RollingPolicyFactory {
+
+    private String totalSize;
+
+    /**
+     * Sets a maximum size of all log files combined. Equivalent to Logback
+     * 'totalSizeCap' property.
+     *
+     * @param totalSize
+     *            maximum size of all log files combined expressed in bytes,
+     *            kilobytes, megabytes or gigabytes by suffixing a numeric value
+     *            with KB, MB and respectively GB. For example: 5000000, 5000KB,
+     *            5MB and 2GB.
+     */
+    public void setTotalSize(String totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    @Override
+    public TimeBasedRollingPolicy instantiatePolicy(LoggerContext context) {
+		TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
+        setupBasePolicySettings(policy);
+		policy.setContext(context);
+		return policy;
+    }
+
+    @Override
+    public TriggeringPolicy<ILoggingEvent> createTriggeringPolicy(LoggerContext context) {
+        return null; // There is no triggering policy
+    }
+
+    @Override
+    protected Class<? extends RollingPolicy> getRollingPolicyType() {
+        return TimeBasedRollingPolicy.class;
+    }
+
+    protected void setupBasePolicySettings(TimeBasedRollingPolicy<ILoggingEvent> policy) {
+        policy.setFileNamePattern(getFileNamePattern());
+        if (getHistorySize() > 0) {
+            policy.setMaxHistory(getHistorySize());
+            policy.setCleanHistoryOnStart(true);
+        }
+        if (totalSize != null && totalSize.length() > 0) {
+            policy.setTotalSizeCap(FileSize.valueOf(totalSize));
+        }
+    }
+}

--- a/bootique-logback/src/main/resources/META-INF/services/com.nhl.bootique.config.PolymorphicConfiguration
+++ b/bootique-logback/src/main/resources/META-INF/services/com.nhl.bootique.config.PolymorphicConfiguration
@@ -1,3 +1,7 @@
 com.nhl.bootique.logback.appender.AppenderFactory
 com.nhl.bootique.logback.appender.ConsoleAppenderFactory
 com.nhl.bootique.logback.appender.FileAppenderFactory
+com.nhl.bootique.logback.policy.RollingPolicyFactory
+com.nhl.bootique.logback.policy.FixedWindowPolicyFactory
+com.nhl.bootique.logback.policy.TimeBasedPolicyFactory
+com.nhl.bootique.logback.policy.SizeAndTimeBasedPolicyFactory

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-10sec-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-10sec-rotation.yml
@@ -1,7 +1,0 @@
-log:
-  level: debug
-  appenders:
-    - type: file
-      logFormat: '%c{20}: %m%n'
-      file: 'target/logs/rotate-by-time/logfile-%d{yyyyMMDDHHmmss}.log'
-      rotate: true

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-fixed-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-fixed-rotation.yml
@@ -1,0 +1,11 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-fixed/logfile-current.log'
+      rollingPolicy:
+        type: fixed
+        fileNamePattern: 'target/logs/rotate-fixed/logfile-%i.log'
+        historySize: 5
+        fileSize: 20

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-maxfiles-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-maxfiles-rotation.yml
@@ -1,8 +1,0 @@
-log:
-  level: debug
-  appenders:
-    - type: file
-      logFormat: '%c{20}: %m%n'
-      file: 'target/logs/rotate-maxfiles/logfile-%d{yyyyMMDDHHmmss}.log'
-      rotate: true
-      maxFiles: 2

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-and-history-and-totalsize-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-and-history-and-totalsize-rotation.yml
@@ -1,0 +1,12 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-by-size-and-history-and-totalsize/logfile-current.log'
+      rollingPolicy:
+        type: size
+        fileNamePattern: 'target/logs/rotate-by-size-and-history-and-totalsize/logfile-%d{yyyyMMDDHHmmss}.%i.log'
+        historySize: 5
+        fileSize: 50
+        totalSize: 150

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-and-history-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-and-history-rotation.yml
@@ -1,0 +1,11 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-by-size-and-history/logfile-current.log'
+      rollingPolicy:
+        type: size
+        fileNamePattern: 'target/logs/rotate-by-size-and-history/logfile-%d{yyyyMMDDHHmmss}.%i.log'
+        historySize: 5
+        fileSize: 40

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-size-rotation.yml
@@ -3,6 +3,8 @@ log:
   appenders:
     - type: file
       logFormat: '%c{20}: %m%n'
-      file: 'target/logs/rotate-by-size/logfile-%d{yyyyMMDD}.%i.log'
-      rotate: true
-      maxFileSize: 20
+      file: 'target/logs/rotate-by-size/logfile-current.log'
+      rollingPolicy:
+        type: size
+        fileNamePattern: 'target/logs/rotate-by-size/logfile-%d{yyyyMMDDHHmmss}.%i.log'
+        fileSize: 40

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-and-totalsize-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-and-totalsize-rotation.yml
@@ -1,0 +1,11 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-by-time-and-history-and-totalsize/logfile-current.log'
+      rollingPolicy:
+        type: time
+        fileNamePattern: 'target/logs/rotate-by-time-and-history-and-totalsize/logfile-%d{yyyyMMDDHHmmss}.log'
+        historySize: 5
+        totalSize: 65

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-rotation.yml
@@ -1,0 +1,10 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-by-time-and-history/logfile-current.log'
+      rollingPolicy:
+        type: time
+        fileNamePattern: 'target/logs/rotate-by-time-and-history/logfile-%d{yyyyMMDDHHmmss}.log'
+        historySize: 5

--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-rotation.yml
@@ -1,0 +1,9 @@
+log:
+  level: debug
+  appenders:
+    - type: file
+      logFormat: '%c{20}: %m%n'
+      file: 'target/logs/rotate-by-time/logfile-current.log'
+      rollingPolicy:
+        type: time
+        fileNamePattern: 'target/logs/rotate-by-time/logfile-%d{yyyyMMDDHHmmss}.log'


### PR DESCRIPTION
Changes:
1) New file appender property 'rollingPolicy' what defines type of rotation; file name pattern of archived log-files; history size of archived log-files; total size of archived log-files (only for rollingPolicy with type 'time' or 'size'); file size of each archived log-file (only for rollingPolicy with type 'size' and 'fixed').
Following types of rolling policy are supported:

- 'time' - implements logback rolling policy 'ch.qos.logback.core.rolling.TimeBasedRollingPolicy'
- 'size' - implements logback rolling policy 'ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy'
- 'fixed' - implements logback rolling policy 'ch.qos.logback.core.rolling.FixedWindowRollingPolicy'

2) FileAppender supports property 'fileName' for current log-file without pattern
3) FileNamePatternValidator implements validation of file name pattern for each rolling policy type
4) FileAppender properties 'rotate', 'maxFiles', 'maxTotalSize', 'maxFileSize' don't supported
5) Unit tests contains checking of each rolling policy type for different configuration

See also unit tests configuration yml-files as examples