### PR TITLE
Fixed LogbackBQConfigIT.testFileAppender_Rotate_By_Time_And_History_And_TotalSize failing on Windows

### DIFF
--- a/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-and-totalsize-rotation.yml
+++ b/bootique-logback/src/test/resources/com/nhl/bootique/logback/test-file-appender-time-and-history-and-totalsize-rotation.yml
@@ -8,4 +8,4 @@ log:
         type: time
         fileNamePattern: 'target/logs/rotate-by-time-and-history-and-totalsize/logfile-%d{yyyyMMDDHHmmss}.log'
         historySize: 5
-        totalSize: 65
+        totalSize: 66


### PR DESCRIPTION
This one is cool 🎱 